### PR TITLE
[MPDF-8] Create one PDF from a multi module project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ under the License.
 
   <properties>
     <doxiaVersion>1.9-SNAPSHOT</doxiaVersion>
-    <doxiaSitetoolsVersion>1.7.5</doxiaSitetoolsVersion>
+    <doxiaSitetoolsVersion>1.8.1</doxiaSitetoolsVersion>
     <mavenVersion>2.2.1</mavenVersion>
   </properties>
 
@@ -240,6 +240,13 @@ under the License.
       </exclusions>
     </dependency>
 
+    <!-- JSON -->
+    <dependency>
+      <groupId>org.kopitubruk.util</groupId>
+      <artifactId>JSONUtil</artifactId>
+      <version>1.10.2-java6</version>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -291,6 +298,27 @@ under the License.
         </executions>
       </plugin>
 <!-- END SNIPPET: configuration -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                  <excludes><!-- DOXIA-554 Markdown parser requires Java 7 (use version 1.7 if you absolutely require Java 6) -->
+                    <exclude>org.apache.maven.doxia:doxia-module-markdown</exclude>
+                    <exclude>org.nibor.autolink:autolink</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/it/pdf-aggregate/invoker.properties
+++ b/src/it/pdf-aggregate/invoker.properties
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #   http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,13 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-toc.title                              = Table des mati\u00e8res
-toc.type                               = Documentation du projet
-toc.project-info.item                  = Rapports Projet
-
-report.project-info.column.description = Description
-report.project-info.column.document    = Document
-report.project-info.sectionTitle       = Vue d'ensemble
-report.project-info.description1       = Ce document fournit une vue d'ensemble des divers documents et liens qui font partie des informations g\u00e9n\u00e9rales du projet. Tous ces contenus sont g\u00e9n\u00e9r\u00e9s automatiquement par
-report.project-info.description2       = le projet lui-m\u00eame.
-report.project-info.title              = Information g\u00e9n\u00e9rale du projet
+invoker.goals = pdf:aggregate
+invoker.debug = false

--- a/src/it/pdf-aggregate/mod-a/pom.xml
+++ b/src/it/pdf-aggregate/mod-a/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.pdf</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-a</artifactId>
+  <name>PDF:aggregate test: module A</name>
+  <description>
+    This is module A for multi-module PDF.
+  </description>
+</project>

--- a/src/it/pdf-aggregate/mod-a/src/site/apt/index.apt
+++ b/src/it/pdf-aggregate/mod-a/src/site/apt/index.apt
@@ -1,0 +1,31 @@
+ ------
+ Multi-module PDF: module A
+ ------
+ Lukas Theussl
+ ------
+ 2009-05-31
+ ------
+
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~   http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+~~ NOTE: For help with the syntax of this file, see:
+~~ http://maven.apache.org/doxia/references/apt-format.html
+
+Overview
+
+  This is module A.

--- a/src/it/pdf-aggregate/mod-a/src/site/site.xml
+++ b/src/it/pdf-aggregate/mod-a/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+  </body>
+</project>

--- a/src/it/pdf-aggregate/mod-b/pom.xml
+++ b/src/it/pdf-aggregate/mod-b/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.pdf</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-b</artifactId>
+  <name>PDF:aggregate test: module B</name>
+  <description>
+    This is module B for multi-module PDF.
+  </description>
+</project>

--- a/src/it/pdf-aggregate/mod-b/src/site/apt/index.apt
+++ b/src/it/pdf-aggregate/mod-b/src/site/apt/index.apt
@@ -1,0 +1,31 @@
+ ------
+ Multi-module PDF: module B
+ ------
+ Lukas Theussl
+ ------
+ 2009-05-31
+ ------
+
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~   http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+~~ NOTE: For help with the syntax of this file, see:
+~~ http://maven.apache.org/doxia/references/apt-format.html
+
+Overview
+
+  This is module B.

--- a/src/it/pdf-aggregate/mod-b/src/site/site.xml
+++ b/src/it/pdf-aggregate/mod-b/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+  </body>
+</project>

--- a/src/it/pdf-aggregate/pom.xml
+++ b/src/it/pdf-aggregate/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.pdf</groupId>
+  <artifactId>root</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>PDF:aggregate test: multi-module root</name>
+  <description>
+    Tests a PDF generation for a multi-module, running pdf:aggregate (that forks pdf:pdf for each module before aggregating).
+  </description>
+
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>http://www.apache.org/</url>
+  </organization>
+
+  <contributors>
+    <contributor>
+      <name>Anthony Beurivé</name>
+    </contributor>
+  </contributors>
+
+  <issueManagement>
+    <system>JIRA</system>
+    <url>https://issues.apache.org/jira/browse/MPDF</url>
+  </issueManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <modules>
+    <module>mod-a</module>
+    <module>mod-b</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pdf-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <reporting>
+    <plugins>
+      <plugin>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>cim</report>
+              <report>dependencies</report><!-- generated xdoc is not valid XML: missing <table> -->
+              <report>dependency-convergence</report><!-- generated xdoc is not valid XML: missing <table> -->
+              <report>dependency-info</report>
+              <report>dependency-management</report>
+              <report>issue-tracking</report>
+              <report>license</report>
+              <report>mailing-list</report>
+              <report>plugins</report>
+              <report>summary</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>  
+  
+</project>

--- a/src/it/pdf-aggregate/src/site/apt/index.apt
+++ b/src/it/pdf-aggregate/src/site/apt/index.apt
@@ -1,0 +1,35 @@
+ ------
+ Multi-module PDF
+ ------
+ Lukas Theussl
+ ------
+ 2009-05-31
+ ------
+
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~   http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+~~ NOTE: For help with the syntax of this file, see:
+~~ http://maven.apache.org/doxia/references/apt-format.html
+
+Overview
+
+  This test shows how multi-module PDF generation works, running:
+
++--------+
+mvn pdf:stage
++--------+

--- a/src/it/pdf-aggregate/src/site/site.xml
+++ b/src/it/pdf-aggregate/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+  </body>
+</project>

--- a/src/it/pdf-aggregate/verify.groovy
+++ b/src/it/pdf-aggregate/verify.groovy
@@ -1,0 +1,25 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+pdfFile = new File( basedir, "target/pdf-aggregate/root.pdf" )
+
+assert pdfFile.text.contains( "PDF:aggregate test: multi-module root" )
+assert pdfFile.text.contains( "PDF:aggregate test: module A" )
+assert pdfFile.text.contains( "PDF:aggregate test: module B" )

--- a/src/main/java/org/apache/maven/plugins/pdf/AbstractPdfMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/AbstractPdfMojo.java
@@ -1,0 +1,68 @@
+package org.apache.maven.plugins.pdf;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.AbstractMojo;
+
+/**
+ * Common code to create pdf, either module pdf or reactor aggregate.
+ * 
+ * @since 1.5
+ */
+public abstract class AbstractPdfMojo
+    extends AbstractMojo
+{
+    protected abstract File getOutputDirectory();
+    protected abstract File getWorkingDirectory();
+    protected abstract boolean isIncludeReports();
+
+    /**
+     * The temp Site dir to have all site and generated-site files.
+     *
+     * @since 1.1
+     */
+    private File siteDirectoryTmp;
+
+    protected abstract void prepareTempSiteDirectory( final File tmpSiteDir )
+        throws IOException;
+
+    /**
+     * @return the default tmpSiteDirectory.
+     * @throws IOException if any
+     * @since 1.1
+     */
+    protected File getSiteDirectoryTmp()
+        throws IOException
+    {
+        if ( this.siteDirectoryTmp == null )
+        {
+            final File tmpSiteDir = new File( getWorkingDirectory(), "site.tmp" );
+            prepareTempSiteDirectory( tmpSiteDir );
+
+            this.siteDirectoryTmp = tmpSiteDir;
+        }
+
+        return this.siteDirectoryTmp;
+    }
+
+}

--- a/src/main/java/org/apache/maven/plugins/pdf/DateBean.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/DateBean.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-
 /**
  * Simple bean to allow date interpolation in the document descriptor, i.e.
  * <pre>
@@ -33,7 +32,6 @@ import java.util.TimeZone;
  * ${date}  = 2009-05-17
  * </pre>
  * @author ltheussl
- * @version $Id$
  */
 public class DateBean
 {
@@ -93,7 +91,6 @@ public class DateBean
     {
         this.date = date;
     }
-
 
     /**
      * @return the year in format "yyyy".

--- a/src/main/java/org/apache/maven/plugins/pdf/DocumentDescriptorReader.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/DocumentDescriptorReader.java
@@ -48,7 +48,6 @@ import java.util.Locale;
  * Read and filter a DocumentModel from a document descriptor file.
  *
  * @author ltheussl
- * @version $Id$
  */
 public class DocumentDescriptorReader
 {

--- a/src/main/java/org/apache/maven/plugins/pdf/DocumentModelBuilder.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/DocumentModelBuilder.java
@@ -43,7 +43,6 @@ import org.apache.commons.io.input.XmlStreamReader;
  * Construct a DocumentModel from a MavenProject and related information.
  *
  * @author ltheussl
- * @version $Id$
  */
 public class DocumentModelBuilder
 {

--- a/src/main/java/org/apache/maven/plugins/pdf/PdfAggregateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/PdfAggregateMojo.java
@@ -1,0 +1,257 @@
+package org.apache.maven.plugins.pdf;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.doxia.document.DocumentModel;
+import org.apache.maven.doxia.document.DocumentTOC;
+import org.apache.maven.doxia.document.DocumentTOCItem;
+import org.apache.maven.model.Reporting;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Forks {@code pdf} goal then aggregates PDF content from all modules in the reactor.
+ *
+ * @author anthony-beurive
+ * @since 1.5
+ */
+@Mojo( name = "aggregate", aggregator = true, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true )
+@Execute( goal = "pdf" )
+public class PdfAggregateMojo
+    extends PdfMojo // TODO should extend AbstractPdfMojo, but requires extensive refactoring
+{
+    /**
+     * The reactor projects.
+     */
+    @Parameter( defaultValue = "${reactorProjects}", required = true, readonly = true )
+    private List<MavenProject> reactorProjects;
+
+    /**
+     * Output directory where aggregated PDF files should be created.
+     */
+    @Parameter( defaultValue = "${project.build.directory}/pdf-aggregate", required = true )
+    private File aggregatedOutputDirectory;
+
+    /**
+     * Working directory for aggregated working files like temp files/resources.
+     */
+    @Parameter( defaultValue = "${project.build.directory}/pdf-aggregate", required = true )
+    private File aggregatedWorkingDirectory;
+
+    protected File getOutputDirectory()
+    {
+        return aggregatedOutputDirectory;
+    }
+
+    protected File getWorkingDirectory()
+    {
+        return aggregatedWorkingDirectory;
+    }
+
+    protected boolean isIncludeReports()
+    {
+        return false; // reports were generate (or not) during pdf:pdf: here, we only aggregate
+    }
+
+    protected void prepareTempSiteDirectory( final File tmpSiteDir )
+        throws IOException
+    {
+        tmpSiteDir.mkdirs();
+    }
+
+    @Override
+    protected void appendGeneratedReports( DocumentModel model, Locale locale )
+    {
+        super.appendGeneratedReports( model, locale );
+
+        getLog().info( "Appending staged reports." );
+
+        DocumentTOC toc = model.getToc();
+
+        File dstSiteTmp = null;
+        try
+        {
+            dstSiteTmp = getSiteDirectoryTmp();
+        }
+        catch ( IOException ioe )
+        {
+            getLog().error( "unexpected IOException while getting aggregator root tmp site dir", ioe );
+        }
+        if ( !dstSiteTmp.exists() )
+        {
+            getLog().error( "Top-level project does not have src.tmp directory" );
+            return;
+        }
+
+        for ( MavenProject reactorProject : reactorProjects )
+        {
+            getLog().info( "Appending " + reactorProject.getArtifactId() + " reports." );
+
+            copySiteDirectoryTmp( reactorProject, dstSiteTmp );
+
+            addTOCItems( toc, reactorProject );
+        }
+    }
+
+    private void copySiteDirectoryTmp( MavenProject project, File dstSiteTmp )
+    {
+        Reporting reporting = project.getReporting();
+        if ( reporting == null )
+        {
+            getLog().info( "Skipping reactor project " + project + ": no reporting" );
+            return;
+        }
+
+        File srcSiteTmp = getModuleSiteDirectoryTmp( project );
+        if ( !srcSiteTmp.exists() )
+        {
+            getLog().info( "Skipping reactor project " + project + ": no site.tmp directory" );
+            return;
+        }
+
+        String stagedId = getStagedId( project );
+
+        try
+        {
+            String defaultExcludes = FileUtils.getDefaultExcludesAsString();
+            List<String> srcDirNames = FileUtils.getDirectoryNames( srcSiteTmp, "*", defaultExcludes, false );
+            for ( String srcDirName : srcDirNames )
+            {
+                File srcDir = new File( srcSiteTmp, srcDirName );
+                File dstDir = new File( new File( dstSiteTmp, srcDirName ), stagedId );
+                if ( !dstDir.exists() && !dstDir.mkdirs() )
+                {
+                    getLog().error( "Could not create directory: " + dstDir );
+                    return;
+                }
+
+                FileUtils.copyDirectoryStructure( srcDir, dstDir );
+            }
+        }
+        catch ( IOException e )
+        {
+            getLog().error( "Error while copying sub-project " + project.getArtifactId()
+                                    + " site.tmp: " + e.getMessage(), e );
+        }
+    }
+
+    private void addTOCItems( DocumentTOC topLevelToc, MavenProject project )
+    {
+        String stagedId = getStagedId( project );
+
+        Map<String, Object> toc = loadToc( project );
+
+        List<Map<String, Object>> items = (ArrayList) toc.get( "items" );
+
+        DocumentTOCItem tocItem = new DocumentTOCItem();
+        tocItem.setName( project.getName() );
+        tocItem.setRef( stagedId );
+
+        if ( items.size() == 1 && "project-info".equals( items.get( 0 ).get( "ref" ) ) )
+        {
+            // Special case where a sub-project only contains generated reports.
+            items = (List) items.get( 0 ).get( "items" );
+        }
+
+        for ( Map<String, Object> item : items )
+        {
+            addTOCItems( tocItem, item, stagedId );
+        }
+
+        topLevelToc.addItem( tocItem );
+    }
+
+    private Map<String, Object> loadToc( MavenProject project )
+    {
+        try
+        {
+            return TocFileHelper.loadToc( getModuleWorkingDirectory( project ) );
+        }
+        catch ( IOException e )
+        {
+            getLog().error( "Error while reading table of contents of module " + project.getArtifactId(), e );
+            return Collections.<String, Object>emptyMap();
+        }
+    }
+
+    private void addTOCItems( DocumentTOCItem parent, Map<String, Object> item, String stagedId )
+    {
+        DocumentTOCItem tocItem = new DocumentTOCItem();
+        tocItem.setName( (String) item.get( "name" ) );
+        tocItem.setRef( stagedId + "/" + item.get( "ref" ) );
+
+        List<Map<String, Object>> items = (ArrayList) item.get( "items" );
+
+        for ( Map<String, Object> it : items )
+        {
+            addTOCItems( tocItem, it, stagedId );
+        }
+
+        parent.addItem( tocItem );
+    }
+
+    private String getStagedId( MavenProject p )
+    {
+        Deque<String> projectPath = new ArrayDeque<String>();
+        projectPath.addFirst( p.getArtifactId() );
+        while ( p.getParent() != null )
+        {
+            p = p.getParent();
+            projectPath.addFirst( p.getArtifactId() );
+        }
+
+        StringBuilder stagedId = new StringBuilder();
+        Iterator<String> artifactIds = projectPath.iterator();
+        while ( artifactIds.hasNext() )
+        {
+            stagedId.append( artifactIds.next() );
+            if ( artifactIds.hasNext() )
+            {
+                stagedId.append( '/' );
+            }
+        }
+        return stagedId.toString();
+    }
+
+    private File getModuleWorkingDirectory( MavenProject project )
+    {
+        return new File( project.getBuild().getDirectory(), "pdf" );
+    }
+
+    private File getModuleSiteDirectoryTmp( MavenProject project )
+    {
+        return new File( getModuleWorkingDirectory( project ), "site.tmp" );
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/pdf/TocFileHelper.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/TocFileHelper.java
@@ -1,0 +1,91 @@
+package org.apache.maven.plugins.pdf;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.maven.doxia.document.DocumentTOC;
+import org.apache.maven.doxia.document.DocumentTOCItem;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.WriterFactory;
+import org.kopitubruk.util.json.IndentPadding;
+import org.kopitubruk.util.json.JSONConfig;
+import org.kopitubruk.util.json.JSONParser;
+import org.kopitubruk.util.json.JSONUtil;
+
+/**
+ * Helper to save then reload TOC content (to a json file), to be able to aggregate TOCs.
+ * 
+ * @author anthony-beurive
+ * @since 1.5
+ */
+class TocFileHelper
+{
+    private static final String FILENAME = "toc.json";
+
+    static void saveTOC( File workingDirectory, DocumentTOC toc, Locale locale )
+        throws IOException
+    {
+        // FIXME: manage locales.
+        JSONConfig jsonConfig = new JSONConfig();
+        jsonConfig.setIndentPadding( new IndentPadding( "  ", "\n" ) );
+        jsonConfig.addReflectClass( DocumentTOC.class );
+        jsonConfig.addReflectClass( DocumentTOCItem.class );
+
+        Writer writer = null;
+        try
+        {
+            writer = WriterFactory.newWriter( getTocFile( workingDirectory ), "UTF-8" );
+            JSONUtil.toJSON( toc, jsonConfig, writer );
+            writer.close();
+            writer = null;
+        }
+        finally
+        {
+            IOUtil.close( writer );
+        }
+    }
+
+    static Map<String, Object> loadToc( File workingDirectory )
+        throws IOException
+    {
+        Reader reader = null;
+        try
+        {
+            reader = ReaderFactory.newReader( getTocFile( workingDirectory ), "UTF-8" );
+            return (Map) JSONParser.parseJSON( reader );
+        }
+        finally
+        {
+            IOUtil.close( reader );
+        }
+    }
+
+    private static File getTocFile( File workingDirectory )
+    {
+        return new File( workingDirectory, FILENAME );
+    }
+}

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -108,7 +108,7 @@ under the License.
           <tr>
             <td>${project.name} ${project.version} (Source zip)</td>
             <td><a href="[preferred]maven/plugins/${project.artifactId}-${project.version}-source-release.zip">maven/plugins/${project.artifactId}-${project.version}-source-release.zip</a></td>
-            <td><a href="http://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.md5">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.md5</a></td>
+            <td><a href="http://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha1">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha1</a></td>
             <td><a href="http://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
           </tr>
         </tbody>

--- a/src/test/java/org/apache/maven/plugins/pdf/DocumentDescriptorReaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/DocumentDescriptorReaderTest.java
@@ -19,7 +19,6 @@ package org.apache.maven.plugins.pdf;
  * under the License.
  */
 
-
 import java.io.File;
 
 import org.apache.maven.doxia.document.DocumentModel;
@@ -30,7 +29,6 @@ import org.codehaus.plexus.PlexusTestCase;
 /**
  *
  * @author ltheussl
- * @version $Id$
  */
 public class DocumentDescriptorReaderTest
         extends PlexusTestCase

--- a/src/test/java/org/apache/maven/plugins/pdf/DocumentModelBuilderTest.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/DocumentModelBuilderTest.java
@@ -40,7 +40,6 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 /**
  *
  * @author ltheussl
- * @version $Id$
  */
 public class DocumentModelBuilderTest
         extends PlexusTestCase

--- a/src/test/java/org/apache/maven/plugins/pdf/PdfMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/PdfMojoTest.java
@@ -30,7 +30,6 @@ import java.io.Reader;
 
 /**
  * @author ltheussl
- * @version $Id$
  */
 public class PdfMojoTest
     extends AbstractMojoTestCase

--- a/src/test/java/org/apache/maven/plugins/pdf/stubs/DefaultMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/stubs/DefaultMavenProjectStub.java
@@ -35,7 +35,6 @@ import org.codehaus.plexus.util.ReaderFactory;
 
 /**
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
- * @version $Id$
  */
 public class DefaultMavenProjectStub
     extends MavenProjectStub

--- a/src/test/java/org/apache/maven/plugins/pdf/stubs/FilteringMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/stubs/FilteringMavenProjectStub.java
@@ -36,7 +36,6 @@ import org.codehaus.plexus.util.ReaderFactory;
 
 /**
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
- * @version $Id$
  */
 public class FilteringMavenProjectStub
     extends MavenProjectStub

--- a/src/test/java/org/apache/maven/plugins/pdf/stubs/ITextMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/stubs/ITextMavenProjectStub.java
@@ -35,7 +35,6 @@ import org.codehaus.plexus.util.ReaderFactory;
 
 /**
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
- * @version $Id$
  */
 public class ITextMavenProjectStub
     extends MavenProjectStub

--- a/src/test/java/org/apache/maven/plugins/pdf/stubs/ModelBuilderMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/stubs/ModelBuilderMavenProjectStub.java
@@ -32,7 +32,6 @@ import org.apache.commons.io.input.XmlStreamReader;
 
 /**
  * @author ltheussl
- * @version $Id$
  */
 public class ModelBuilderMavenProjectStub
     extends MavenProjectStub


### PR DESCRIPTION
An attempt to fix [MPDF-8](https://issues.apache.org/jira/browse/MPDF-8).

It makes `maven-pdf-plugin` look a bit more like `maven-site-plugin` in that it adds a `pdf:stage` goal which aggregates the intermediate outputs of `pdf:pdf` of each sub-module.

It is a working solution (at least in another project I work on) but nothing is perfect. TOC numbering seems wrong in final PDF (maybe not using a recent doxia with closed [DOXIA-564](https://issues.apache.org/jira/browse/DOXIA-564); dependency issue on my part?).

I used JSON to serialize/deserialize the TOC of each sub-module but I can only start to guess it isn't standard maven way.

Comments are welcome.