### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pdf/DocumentModelBuilder.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/DocumentModelBuilder.java
@@ -98,7 +98,7 @@ public class DocumentModelBuilder {
      * @return a DocumentModel. Always non-null.
      */
     private static DocumentModel getDocumentModel(MavenProject project, DecorationModel decorationModel, Date date) {
-        final Date now = (date == null ? new Date() : date);
+        final Date now = date == null ? new Date() : date;
 
         final DocumentModel docModel = new DocumentModel();
 
@@ -278,7 +278,7 @@ public class DocumentModelBuilder {
             // nop
         }
 
-        if (StringUtils.isEmpty(encoding)) {
+        if (encoding == null || encoding.isEmpty()) {
             return "UTF-8";
         }
 

--- a/src/main/java/org/apache/maven/plugins/pdf/PdfMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pdf/PdfMojo.java
@@ -1197,7 +1197,7 @@ public class PdfMojo extends AbstractPdfMojo implements Contextualizable {
      * @since 1.1
      */
     private static void writeGeneratedReport(String content, File toFile) throws IOException {
-        if (StringUtils.isEmpty(content)) {
+        if (content == null || content.isEmpty()) {
             return;
         }
 

--- a/src/test/java/org/apache/maven/plugins/pdf/PdfMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pdf/PdfMojoTest.java
@@ -43,7 +43,6 @@ import java.io.Reader;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 
 /**
@@ -95,7 +94,7 @@ public class PdfMojoTest extends AbstractMojoTestCase {
         assertTrue(foContent.indexOf("1.0-SNAPSHOT") > 0);
         // env ${M2_HOME}
         String m2Home = CommandLineUtils.getSystemEnvVars().getProperty("M2_HOME");
-        if (StringUtils.isNotEmpty(m2Home)) {
+        if (m2Home != null && !m2Home.isEmpty()) {
             assertTrue(foContent.indexOf(m2Home) > 0);
         }
         // ${project.developers[0].email}


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu