### PR TITLE
[MPDF-113] Retire PDF plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,87 +14,17 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-Contributing to [Apache Maven PDF Plugin](https://maven.apache.org/plugins/maven-pdf-plugin/)
-======================
+RETIRED - [Apache Maven PDF Plugin](https://maven.apache.org/plugins/maven-pdf-plugin/)
+
 
 [![ASF Jira](https://img.shields.io/endpoint?url=https%3A%2F%2Fmaven.apache.org%2Fbadges%2Fasf_jira-MPDF.json)][jira]
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-pdf-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-pdf-plugin)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/apache/maven/plugins/maven-pdf-plugin/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/maven/plugins/maven-pdf-plugin/README.md)
-[![Jenkins Status](https://img.shields.io/jenkins/s/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-pdf-plugin/job/master.svg?)][build]
-[![Jenkins tests](https://img.shields.io/jenkins/t/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-pdf-plugin/job/master.svg?)][test-results]
 
-
-You have found a bug or you have an idea for a cool new feature? Contributing
-code is a great way to give something back to the open source community. Before
-you dig right into the code, there are a few guidelines that we need
-contributors to follow so that we can have a chance of keeping on top of
-things.
-
-Getting Started
----------------
-
-+ Make sure you have a [JIRA account](https://issues.apache.org/jira/).
-+ Make sure you have a [GitHub account](https://github.com/signup/free).
-+ If you're planning to implement a new feature, it makes sense to discuss your changes 
-  on the [dev list][ml-list] first. 
-  This way you can make sure you're not wasting your time on something that isn't 
-  considered to be in Apache Maven's scope.
-+ Submit a ticket for your issue, assuming one does not already exist.
-  + Clearly describe the issue, including steps to reproduce when it is a bug.
-  + Make sure you fill in the earliest version that you know has the issue.
-+ Fork the repository on GitHub.
-
-Making and Submitting Changes
---------------
-
-We accept Pull Requests via GitHub. The [developer mailing list][ml-list] is the
-main channel of communication for contributors.  
-There are some guidelines which will make applying PRs easier for us:
-+ Create a topic branch from where you want to base your work (this is usually the master branch).
-  Push your changes to a topic branch in your fork of the repository.
-+ Make commits of logical units.
-+ Respect the original code style: by using the same [codestyle][code-style],
-  patches should only highlight the actual difference, not being disturbed by any formatting issues:
-  + Only use spaces for indentation.
-  + Create minimal diffs - disable on save actions like reformat source code or organize imports. 
-    If you feel the source code should be reformatted, create a separate PR for this change.
-  + Check for unnecessary whitespace with `git diff --check` before committing.
-+ Make sure your commit messages are in the proper format. Your commit message should contain the key of the JIRA issue.
-```
-[MPDF-XXX] - Subject of the JIRA Ticket
- Optional supplemental description.
-```
-+ Make sure you have added the necessary tests (JUnit/IT) for your changes.
-+ Run all the tests with `mvn -Prun-its verify` to assure nothing else was accidentally broken.
-+ Submit a pull request to the repository in the Apache organization.
-+ Update your JIRA ticket and include a link to the pull request in the ticket.
-
-If you plan to contribute on a regular basis, please consider filing a [contributor license agreement][cla].
-
-Making Trivial Changes
-----------------------
-
-For changes of a trivial nature to comments and documentation, it is not always
-necessary to create a new ticket in JIRA.  In this case, it is appropriate to
-start the first line of a commit with '(doc)' instead of a ticket number.
-
-Additional Resources
---------------------
-
-+ [Contributing patches](https://maven.apache.org/guides/development/guide-maven-development.html#Creating_and_submitting_a_patch)
-+ [Apache Maven PDF Plugin JIRA project page][jira]
-+ [Contributor License Agreement][cla]
-+ [General GitHub documentation](https://help.github.com/)
-+ [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
-+ [Apache Maven Twitter Account](https://twitter.com/ASFMavenProject)
-+ #Maven IRC channel on freenode.org
+This plugin is retired. It is no longer maintained.
+===================================================
 
 [jira]: https://issues.apache.org/jira/projects/MPDF/
 [license]: https://www.apache.org/licenses/LICENSE-2.0
-[ml-list]: https://maven.apache.org/mailing-lists.html
-[code-style]: https://maven.apache.org/developers/conventions/code.html
-[cla]: https://www.apache.org/licenses/#clas
-[maven-wiki]: https://cwiki.apache.org/confluence/display/MAVEN/Index
-[test-results]: https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-pdf-plugin/job/master/lastCompletedBuild/testReport/
-[build]: https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-pdf-plugin/job/master/
+

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
   <version>1.6.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
-  <name>Apache Maven PDF Plugin</name>
+  <name>(RETIRED) Apache Maven PDF Plugin</name>
   <description>Generates a PDF document from the project site.</description>
 
   <contributors>

--- a/src/site/apt/examples/filtering.apt
+++ b/src/site/apt/examples/filtering.apt
@@ -28,6 +28,7 @@
 
 Filtering Document Descriptor
 
+  <<<Note:>>> This plugin is retired. It is no longer maintained.
   The document descriptor (aka src/site/pdf.xml) could be filtered by System properties, Maven project properties and
   some date properties.
 

--- a/src/site/apt/examples/filtering.apt
+++ b/src/site/apt/examples/filtering.apt
@@ -29,6 +29,8 @@
 Filtering Document Descriptor
 
   <<<Note:>>> This plugin is retired. It is no longer maintained.
+
+
   The document descriptor (aka src/site/pdf.xml) could be filtered by System properties, Maven project properties and
   some date properties.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -30,6 +30,7 @@ ${project.name}
 
   <<<Note:>>> This plugin is retired. It is no longer maintained.
 
+
   This plug-in allows you to generate a PDF version of your
   project's documentation.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -28,6 +28,8 @@
 
 ${project.name}
 
+  <<<Note:>>> This plugin is retired. It is no longer maintained.
+
   This plug-in allows you to generate a PDF version of your
   project's documentation.
 

--- a/src/site/apt/limitations.apt
+++ b/src/site/apt/limitations.apt
@@ -28,7 +28,9 @@
 
 Known Bugs and Limitations
 
-<<<Note:>>> This plugin is retired. It is no longer maintained.
+  <<<Note:>>> This plugin is retired. It is no longer maintained.
+
+
 
   Just a brief selection...
 

--- a/src/site/apt/limitations.apt
+++ b/src/site/apt/limitations.apt
@@ -28,6 +28,8 @@
 
 Known Bugs and Limitations
 
+<<<Note:>>> This plugin is retired. It is no longer maintained.
+
   Just a brief selection...
 
 * Missing Features

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -29,6 +29,8 @@
 Using The PDF Plugin
 
    <<<Note:>>> This plugin is retired. It is no longer maintained.
+
+
   The Maven PDF Plugin allows you generate a PDF document of your documentation.
 
 * From The Command-line

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -28,6 +28,7 @@
 
 Using The PDF Plugin
 
+   <<<Note:>>> This plugin is retired. It is no longer maintained.
   The Maven PDF Plugin allows you generate a PDF document of your documentation.
 
 * From The Command-line
@@ -149,7 +150,7 @@ Using The PDF Plugin
   located in <<<src/site/resources/>>>.
 
   The format of this file has to be exactly the same as the original
-  {{{https://github.com/apache/maven-doxia/blob/master/doxia-modules/doxia-module-fo/src/main/resources/fo-styles.xslt}default configuration file}}.
+  {{{https://github.com/apache/maven-doxia/blob/doxia-1.x/doxia-modules/doxia-module-fo/src/main/resources/fo-styles.xslt}default configuration file}}.
   However, you only need to specify the properties that you want to override,
   <e.g.> to change the font size of pre-formatted text, you could use:
 

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8 ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
+<?xml version="1.0" encoding="UTF-8 ?>
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -24,6 +24,8 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/FML/1.0.1 http://maven.apache.org/xsd/fml-1.0.1.xsd"
   title="Frequently Asked Questions">
 
+  <b>Note</b> This plugin is retired. It is no longer maintained.
+
   <part id="General">
     <title>General</title>
 
@@ -31,8 +33,7 @@ under the License.
       <question>Is it possible to create a book?</question>
       <answer>
         <p>
-          The <a href="http://svn.apache.org/repos/asf/maven/doxia/doxia/trunk/doxia-book/">Doxia Book code</a>
-          currently only supports the iText module for generating a pdf book.
+          You can generating pdf books using <a href="https://maven.apache.org/doxia/book/index.html">Doxia Book</a>.
         </p>
       </answer>
     </faq>
@@ -42,8 +43,8 @@ under the License.
       <answer>
         <p>
           You can use the same graphics formats as are supported by the chosen implementation, eg see
-          <a href="http://xmlgraphics.apache.org/fop/0.94/graphics.html">Apache FOP Graphics Formats</a>
-          and <a href="http://itextdocs.lowagie.com/tutorial/objects/images/index.php">iText Images</a>.
+          <a href="https://xmlgraphics.apache.org/fop/0.95/graphics.html">Apache FOP Graphics Formats</a>
+          and iText Images.
           You should probably take care of image resolution, see bellow.
         </p>
       </answer>
@@ -59,7 +60,7 @@ under the License.
       <answer>
         <p>
           This is most likely a resolution problem, for instance your image was saved with a 72 dpi resolution.
-          Try to use an image with a higher resolution, like 96 dpi. You could resize your image whith this
+          Try to use an image with a higher resolution, like 96 dpi. You could resize your image width this
           program: <a href="http://www.gimp.org/">gimp</a>.
           This is the only solution if you include the image from an apt source file
           (since in apt there is no possibility to specify the size of an image), if you are using

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -31,7 +31,6 @@ under the License.
       <item name="Usage" href="usage.html"/>
       <item name="Limitations" href="limitations.html"/>
       <item name="FAQ" href="faq.html"/>
-      <item name="PDF" href="maven-pdf-plugin.pdf"/>
       <!-- According to https://issues.apache.org/jira/browse/MNGSITE-152 -->
       <item name="License" href="http://www.apache.org/licenses/"/>
       <item name="Download" href="download.html"/>

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -25,101 +25,20 @@ under the License.
   </properties>
   <body>
     <section name="Download ${project.name} ${project.version} Source">
+        <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
+        <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
+        <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
+        <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
-      <p>${project.name} ${project.version} is distributed in source format. Use a source archive if you intend to build
-      ${project.name} yourself. Otherwise, simply use the ready-made binary artifacts from central repository.</p>
+        <a name="mirror"/>
+        <subsection name="Files">
+            <p><strong>This plugin is retired. It is no longer maintained.</strong></p>
+            <p>Historical releases can be found on our <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
 
-      <p>You will be prompted for a mirror - if the file is not found on yours, please be patient, as it may take 24
-      hours to reach all mirrors.<p/>
-
-      <p>In order to guard against corrupted downloads/installations, it is highly recommended to
-      <a href="http://www.apache.org/dev/release-signing#verifying-signature">verify the signature</a>
-      of the release bundles against the public <a href="https://www.apache.org/dist/maven/KEYS">KEYS</a> used by the Apache Maven
-      developers.</p>
-
-      <p>${project.name} is distributed under the <a href="http://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
-
-      <p></p>We <b>strongly</b> encourage our users to configure a Maven repository mirror closer to their location, please read <a href="/guides/mini/guide-mirror-settings.html">How to Use Mirrors for Repositories</a>.</p>
-
-      <a name="mirror"/>
-      <subsection name="Mirror">
-
-        <p>
-          [if-any logo]
-          <a href="[link]">
-            <img align="right" src="[logo]" border="0"
-                 alt="logo"/>
-          </a>
-          [end]
-          The currently selected mirror is
-          <b>[preferred]</b>.
-          If you encounter a problem with this mirror,
-          please select another mirror.
-          If all mirrors are failing, there are
-          <i>backup</i>
-          mirrors
-          (at the end of the mirrors list) that should be available.
-        </p>
-
-        <form action="[location]" method="get" id="SelectMirror">
-          Other mirrors:
-          <select name="Preferred">
-            [if-any http]
-            [for http]
-            <option value="[http]">[http]</option>
-            [end]
-            [end]
-            [if-any ftp]
-            [for ftp]
-            <option value="[ftp]">[ftp]</option>
-            [end]
-            [end]
-            [if-any backup]
-            [for backup]
-            <option value="[backup]">[backup] (backup)</option>
-            [end]
-            [end]
-          </select>
-          <input type="submit" value="Change"/>
-        </form>
-
-        <p>
-          You may also consult the
-          <a href="http://www.apache.org/mirrors/">complete list of
-            mirrors.</a>
-        </p>
-
-      </subsection>
-      
-      <subsection name="${project.name} ${project.version}">
-        
-      <p>This is the current stable version of ${project.name}.</p>
-        
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>Link</th>
-            <th>Checksum</th>
-            <th>Signature</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>${project.name} ${project.version} (Source zip)</td>
-            <td><a href="[preferred]maven/plugins/${project.artifactId}-${project.version}-source-release.zip">maven/plugins/${project.artifactId}-${project.version}-source-release.zip</a></td>
-            <td><a href="https://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
-            <td><a href="https://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
-          </tr>
-        </tbody>
-      </table>
-      </subsection>
-
-      <subsection name="Previous Versions">
-        
-      <p>Older non-recommended releases can be found on our <a href="http://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
-
-      </subsection>
+            <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+            using the checksum (.sha512 file) or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
+            </p>
+        </subsection>
     </section>
   </body>
 </document>

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -30,7 +30,6 @@ under the License.
         <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
         <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
-        <a name="mirror"/>
         <subsection name="Files">
             <p><strong>This plugin is retired. It is no longer maintained.</strong></p>
             <p>Historical releases can be found on our <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>

--- a/src/site/xdoc/examples/configuring-reports.xml.vm
+++ b/src/site/xdoc/examples/configuring-reports.xml.vm
@@ -30,6 +30,10 @@ under the License.
 
   <body>
     <section name="Configuring Reports">
+        <p>
+            <b>Note</b> This plugin is retired. It is no longer maintained.
+        </p>
+
       <p>
         Since version 1.1, all Maven reports will be included by default in the generated PDF.
         You should configure the &lt;reporting/&gt; section of your POM similar than the


### PR DESCRIPTION
Updates pages to indicate the plugin has been retired.

Broken links were also corrected or removed (see [MPDF-111])
